### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,7 +72,7 @@ jobs:
             fail-build: false
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: rupesh1050/rupeshaccern
           username: ${{ secrets.DOCKER_NAME }}
@@ -153,7 +153,7 @@ jobs:
             fail-build: false
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: rupesh1050/cicd-workflow
           username: ${{ secrets.DOCKER_NAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore